### PR TITLE
Improve rank system and add tooltip

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -67,6 +67,12 @@ interface ApiResponse {
     hours: Record<string, { trades: number; winRate: number; avgPnl: number; totalPnl: number }>;
   };
   openPositions: { symbol: string; side: string; size: number; entryPrice: number; unrealizedPnl: number }[];
+  calculationExplanation?: {
+    title: string;
+    description: string;
+    factors: { name: string; weight: string; description: string }[];
+    ranks: { name: string; range: string; description: string }[];
+  };
 }
 
 /* ───────── Helpers ───────── */
@@ -80,6 +86,7 @@ export default function Page() {
   const [stats, setStats] = useState<ApiResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [showRankInfo, setShowRankInfo] = useState(false);
 
   const fetchStats = async () => {
     if (!wallet.trim()) {
@@ -557,9 +564,33 @@ export default function Page() {
                     <StatCard label="Volume" value={usd(stats.volume)} />
                     
                     {/* Trader Rank Section */}
-                    <div className="col-span-2 bg-gradient-to-br from-gray-800/80 to-gray-700/60 border border-yellow-500/50 rounded p-3 backdrop-blur-sm">
-                      <div className="text-xs font-semibold text-green-400 mb-2 tracking-wide">
+                    <div className="relative col-span-2 bg-gradient-to-br from-gray-800/80 to-gray-700/60 border border-yellow-500/50 rounded p-3 backdrop-blur-sm">
+                      <div className="text-xs font-semibold text-green-400 mb-2 tracking-wide flex items-center gap-1">
                         TRADER RANK
+                        <span
+                          className="relative ml-1"
+                          onMouseEnter={() => setShowRankInfo(true)}
+                          onMouseLeave={() => setShowRankInfo(false)}
+                        >
+                          <span className="cursor-pointer text-gray-300">?</span>
+                          {showRankInfo && stats.calculationExplanation && (
+                            <div className="absolute left-0 top-full z-10 mt-1 w-72 rounded-lg bg-gray-800 p-3 text-sm text-gray-200 shadow-lg">
+                              <div className="font-bold text-green-400 mb-1">
+                                {stats.calculationExplanation.title}
+                              </div>
+                              <p className="mb-2 text-gray-300">
+                                {stats.traderRank.description}
+                              </p>
+                              <ul className="list-disc list-inside space-y-1">
+                                {stats.calculationExplanation.factors.map((f, i) => (
+                                  <li key={i}>
+                                    <span className="font-semibold">{f.name}</span> ({f.weight})
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                          )}
+                        </span>
                       </div>
                       
                       <div className="flex items-center justify-center">

--- a/confidence_calculator.py
+++ b/confidence_calculator.py
@@ -169,71 +169,71 @@ class ConfidenceCalculator:
             
             # 1. WIN RATE SCORING (40% weight) - Most important
             if win_rate >= 0.75:        # 75%+ exceptional
-                score += 35
-            elif win_rate >= 0.65:      # 65%+ excellent  
-                score += 25
+                score += 30
+            elif win_rate >= 0.65:      # 65%+ excellent
+                score += 20
             elif win_rate >= 0.55:      # 55%+ very good
-                score += 15
+                score += 10
             elif win_rate >= 0.50:      # 50%+ good
                 score += 5
             elif win_rate >= 0.45:      # 45%+ average
                 score -= 5
             elif win_rate >= 0.40:      # 40%+ below average
-                score -= 15
+                score -= 10
             elif win_rate >= 0.30:      # 30%+ poor
-                score -= 25
+                score -= 20
             else:                       # <30% very poor
-                score -= 35
+                score -= 30
             
             # 2. PNL SCORING (35% weight) - Second most important
             if total_pnl >= 100000:     # $100k+ is diamond tier
-                score += 30
+                score += 25
             elif total_pnl >= 50000:    # $50k+ excellent
-                score += 20
+                score += 18
             elif total_pnl >= 25000:    # $25k+ very good
-                score += 15
+                score += 12
             elif total_pnl >= 10000:    # $10k+ good
-                score += 10
+                score += 8
             elif total_pnl >= 5000:     # $5k+ okay
-                score += 5
+                score += 4
             elif total_pnl >= 1000:     # $1k+ neutral
                 score += 0
             elif total_pnl >= 0:        # Break even
-                score -= 5
+                score -= 4
             elif total_pnl >= -5000:    # Small loss
-                score -= 10
+                score -= 8
             elif total_pnl >= -10000:   # Medium loss
-                score -= 20
+                score -= 16
             else:                       # Large loss
-                score -= 30
+                score -= 24
             
             # 3. RISK/REWARD RATIO (15% weight)
             if avg_win > 0 and avg_loss < 0:
                 risk_reward = abs(avg_win / avg_loss)
                 if risk_reward >= 3.0:      # Excellent 3:1
-                    score += 15
+                    score += 12
                 elif risk_reward >= 2.0:    # Very good 2:1
-                    score += 10
+                    score += 8
                 elif risk_reward >= 1.5:    # Good 1.5:1
-                    score += 5
+                    score += 4
                 elif risk_reward >= 1.0:    # Break even 1:1
                     score += 0
                 elif risk_reward >= 0.8:    # Below par
-                    score -= 5
+                    score -= 4
                 else:                       # Poor risk management
-                    score -= 10
+                    score -= 8
             
             # 4. SAMPLE SIZE BONUS (10% weight) - Confidence in data
             if len(trades) >= 1000:     # Very high confidence
-                score += 10
+                score += 8
             elif len(trades) >= 500:    # High confidence
-                score += 7
+                score += 6
             elif len(trades) >= 200:    # Good confidence
-                score += 5
+                score += 4
             elif len(trades) >= 100:    # Moderate confidence
-                score += 3
+                score += 2
             elif len(trades) >= 50:     # Low confidence
-                score += 1
+                score += 0
             else:                       # Very low confidence
                 score -= 2
             


### PR DESCRIPTION
## Summary
- tweak confidence score calculation
- expose rank calculation info in UI
- show tooltip describing rank factors

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b442338888331a36b53a5f129dcc9